### PR TITLE
added static to gitignore, csrf_trusted_origin in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # project folders
 .git-ignore/
+datafundament_fb/static/
 
 # project files
 *.sqlite3

--- a/datafundament_fb/datafundament_fb/settings/base.py
+++ b/datafundament_fb/datafundament_fb/settings/base.py
@@ -131,3 +131,6 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Auth settings
 LOGIN_URL = '/admin/login/'
 LOGOUT_REDIRECT_URL = '/'
+
+# CSRF settings
+CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost').split(',')


### PR DESCRIPTION
- static map toegevoegd aan .gitignore
- csrf_token_origins toegevoegd aan basy.py settings. Deze is nodig om POST te kunnen doen in forms. 