### PR TITLE
Hotfix/download empty csv

### DIFF
--- a/datafundament_fb/locations/tests/test_views.py
+++ b/datafundament_fb/locations/tests/test_views.py
@@ -504,7 +504,7 @@ class TestLocationImportForm(TestCase):
         # Verify response message
         messages = [msg for msg in get_messages(response.wsgi_request)]
         self.assertEqual(messages[0].tags, 'error')
-        self.assertEqual(messages[0].message, "De locaties kunnen niet ingelezen worden. Zorg ervoor dat je ';' als scheidingsteken gebruikt.")
+        self.assertEqual(messages[0].message, "De locaties kunnen niet ingelezen worden. Zorg ervoor dat je ';' als scheidingsteken en UTF-8 als codering gebruikt.")
 
     def test_import_csv_with_excess_columns(self):
         """ Test csv import when a data row has more columns than the header; for instance when a value has a semicolon"""

--- a/datafundament_fb/locations/views.py
+++ b/datafundament_fb/locations/views.py
@@ -144,12 +144,13 @@ class LocationImportView(LoginRequiredMixin, View):
         if form.is_valid():
             csv_file = form.cleaned_data.get('csv_file')
             if csv_file.name.endswith('.csv'):
-                csv_reader = csv_file.read().decode('utf-8-sig').splitlines()
-                # Set the correct format for the csv by 'sniffing' the first line of the csv data and setting the delimiter
                 try:
+                    # Read the file as an utf-8 file
+                    csv_reader = csv_file.read().decode('utf-8-sig').splitlines()
+                    # Set the correct format for the csv by 'sniffing' the first line of the csv data and setting the delimiter
                     csv_dialect = csv.Sniffer().sniff(sample=csv_reader[0], delimiters=';')
                 except:
-                    message = "De locaties kunnen niet ingelezen worden. Zorg ervoor dat je ';' als scheidingsteken gebruikt."
+                    message = "De locaties kunnen niet ingelezen worden. Zorg ervoor dat je ';' als scheidingsteken en UTF-8 als codering gebruikt."
                     messages.add_message(request, messages.ERROR, message)
                     
                     return HttpResponseRedirect(reverse('locations_urls:location-import'))


### PR DESCRIPTION
- Wanneer er geen locaties in de database staan wordt een lege csv met enkel de kolomnamen ge-exporteerd
- Het inlezen van een csv import is binnen een try blok gezet zodat coderingsfouten kunnen worden afgevangen