### PR TITLE
fix decimal localization by browser for number types

### DIFF
--- a/datafundament_fb/locations/forms.py
+++ b/datafundament_fb/locations/forms.py
@@ -40,14 +40,14 @@ def set_location_property_fields(include_private_properties: bool=False)-> dict:
                     label=location_property.label,
                     required=location_property.required,
                     validators=[validators.valid_geolocation],
-                    widget=forms.NumberInput
+                    widget=forms.TextInput
                 )
             case 'NUM':
                 fields[location_property.short_name] = forms.CharField(
                     label=location_property.label,
                     required=location_property.required,
                     validators=[validators.valid_number],
-                    widget=forms.NumberInput
+                    widget=forms.TextInput
                 )
             case 'MEMO':
                 fields[location_property.short_name] = forms.CharField(


### PR DESCRIPTION
Bij het opslaan van locatie data met een komma getal gaat die fout omdat de browser een komma getal omzet naar een punt wanneer het input veld als 'number' is gedefinieerd. Daarom zowel voor Geolocatie als Numeriek gegevens type het input type omgezet naar text. 