### PR TITLE
Bug/restricted constrained propertyoption delete

### DIFF
--- a/datafundament_fb/locations/tests/test_views.py
+++ b/datafundament_fb/locations/tests/test_views.py
@@ -980,3 +980,30 @@ class TestListViewPaginator(TestCase):
         # Verify that the mock attribute is called
         self.assertTrue(mock.called)
 
+
+class TestPropertyOptionDeleteView(TestCase):
+    """
+    Test the PropertyOptionDeleteView
+    """
+    fixtures = [
+        'locations',
+        'property_groups',
+        'location_properties',
+        'property_options',
+        'location_data',
+        'external_services',
+        'location_external_services',
+    ]
+
+    def test_restricted_error(self):
+        # get property option related to a location
+        property_option = PropertyOption.objects.filter(locationdata__location__isnull=False).first()
+        # post delete request
+        url = reverse('locations_urls:propertyoption-delete', args=[property_option.location_property.id, property_option.id])
+        user = User.objects.create(username='testuser', is_superuser=False, is_staff=True)
+        self.client.force_login(user)
+        response = self.client.post(path=url)
+        # check for the error message in the response
+        error_message = [msg for msg in get_messages(response.wsgi_request)][0].message
+        expected_message = f"Optie '{property_option.option}' kan niet verwijderd worden, want er zijn nog locatie(s) aan gekoppeld."
+        self.assertEqual(error_message, expected_message)

--- a/datafundament_fb/locations/views.py
+++ b/datafundament_fb/locations/views.py
@@ -492,7 +492,7 @@ class PropertyOptionDeleteView(LoginRequiredMixin, DeleteView):
         try:
             self.object.delete()
         except (ProtectedError, RestrictedError) as error:
-            messages.error(self.request, f"Optie '{self.object.option} kan niet verwijderd worden, want er zijn nog locatie(s) aan gekoppeld.")
+            messages.error(self.request, f"Optie '{self.object.option}' kan niet verwijderd worden, want er zijn nog locatie(s) aan gekoppeld.")
             return super().form_invalid(form)
         else:
             messages.success(self.request, f"Optie '{self.object.option}' is verwijderd.")


### PR DESCRIPTION
Als een PropertyOption wordt verwijderd waar locatie_data aan gekoppeld is dan treed er een RestrictedError op. Deze moet worden afgevangen en teruggekoppeld worden aan de gebruiker.

- test toegevoegd. 