### PR TITLE
unique constraint validation for propertyoption

### DIFF
--- a/datafundament_fb/locations/views.py
+++ b/datafundament_fb/locations/views.py
@@ -457,7 +457,7 @@ class PropertyOptionCreateView(LoginRequiredMixin, CreateView):
         form.instance.location_property = self.location_property
         # Added try because location_property field is excluded from the form and unqiue constraint is therefore not handled by modelform
         try:
-            form.save()
+            self.object = form.save()
         except IntegrityError as err:
             form.add_error(None, f"'{form.instance.option}' bestaat al in {form.instance.location_property.label}.")
             return self.form_invalid(form)
@@ -481,7 +481,7 @@ class PropertyOptionUpdateView(LoginRequiredMixin, UpdateView):
     def form_valid(self, form):
         # Added try because location_property field is excluded from the form and unqiue constraint is therefore not handled by modelform
         try:
-            form.save()
+            self.object = form.save()
         except IntegrityError as err:
             form.add_error(None, f"'{form.instance.option}' bestaat al in {form.instance.location_property.label}.")
             return self.form_invalid(form)


### PR DESCRIPTION
Try/except toegevoegd bij het aanmaken/updaten van een PropertyOption om te controleren of de waarde niet al voorkomt in de database. Omdat het veld location_property uitgezonderd is van het form wordt de unique constraint (voor de velden location_property en option) in dit geval niet afgehandeld door modelform en veroorzaakt een save() van de instance een integrityerror in de database.