### PR TITLE
fix: custom `OIDC_RP_SCOPES` are defined, so the `verify_claims` should be overwritten

### DIFF
--- a/src/main/auth.py
+++ b/src/main/auth.py
@@ -1,0 +1,19 @@
+import logging
+
+from amsterdam_django_oidc import OIDCAuthenticationBackend as AmsterdamOIDCAuthenticationBackend
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OIDCAuthenticationBackend(AmsterdamOIDCAuthenticationBackend):
+    """Override Amsterdam OIDC authentication."""
+
+    def verify_claims(self, claims):
+        """Verify the provided claims to decide if authentication should be allowed."""
+
+        # Verify claims required by default configuration
+        scopes = self.get_settings("OIDC_RP_SCOPES", "openid email")
+        if "email" in scopes.split():
+            return "email" in claims
+
+        return True

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -241,7 +241,7 @@ REQUEST_CHANGE_FORM_URL = "https://forms.office.com/Pages/ResponsePage.aspx?id=s
 
 # Authentication settings
 AUTHENTICATION_BACKENDS = [
-    "amsterdam_django_oidc.OIDCAuthenticationBackend",
+    "main.auth.OIDCAuthenticationBackend",
 ]
 LOGIN_URL = "oidc_authentication_init"
 LOGOUT_URL = "oidc_logout"


### PR DESCRIPTION
The `OIDCAuthenticationBackend` backend from the `amsterdam_django_oidc` uses the `OIDCAuthenticationBackend` from `mozilla_django_oidc` which writes a log waringin when custom scopes (`OIDCAuthenticationBackend`) are used. So in this PR the `verify_claims` is overwritten to get rid of the log message.